### PR TITLE
Fix and new function

### DIFF
--- a/DS3231.h
+++ b/DS3231.h
@@ -129,6 +129,8 @@ class DS3231
 	char* dateFormat(const char* dateFormat, RTCDateTime dt);
 	char* dateFormat(const char* dateFormat, RTCAlarmTime dt);
 
+    static RTCDateTime LoadDateTimeFromLong(uint32_t t);
+
     private:
 	RTCDateTime t;
 


### PR DESCRIPTION
fix #7 problem with unix when is leap year.

add LoadDataTimeFromLong:
Return a instance of RTCDateTime from LONG without modifying the current
data